### PR TITLE
Revert "Changes paths to match Windows standards."

### DIFF
--- a/src/imp/platform/windows.rs
+++ b/src/imp/platform/windows.rs
@@ -31,9 +31,9 @@ pub const USE_AUTHOR: bool = true;
 
 pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
     let folder_id = match t {
-        UserConfig => &FOLDERID_RoamingAppData,
+        UserConfig | UserData => &FOLDERID_RoamingAppData,
         SharedConfig | SharedData => &FOLDERID_ProgramData,
-        UserCache | UserData => &FOLDERID_LocalAppData,
+        UserCache => &FOLDERID_LocalAppData,
     };
     get_folder_path(folder_id).map(|os_str| os_str.into())
 }


### PR DESCRIPTION
rel https://github.com/paritytech/parity/issues/8418

This reverts commit ab58239b56fd5bbad8e47ce97051b74f6a68a066.